### PR TITLE
An array of level can have an integer value & event ['tags'] can just be a value not always an array

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -178,7 +178,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
       if event["tags"].is_a?(Array)
         m["_tags"] = event["tags"].join(', ')
       else
-        m["_tags"] = event["tags"]
+        m["_tags"] = event["tags"] if event["tags"]
       end
     end
 

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -175,7 +175,11 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     end
 
     if @ship_tags
-      m["_tags"] = event["tags"].join(', ') if event["tags"]
+      if event["tags"].is_a?(Array)
+        m["_tags"] = event["tags"].join(', ')
+      else
+        m["_tags"] = event["tags"]
+      end
     end
 
     if @custom_fields
@@ -191,7 +195,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
         parsed_value = event.sprintf(value)
         next if value.count('%{') > 0 and parsed_value == value
 
-        level = parsed_value
+        level = parsed_value.to_s
         break
       end
     else


### PR DESCRIPTION
I found 2 issues:

1/An array of level can have an integer value, currently the code convert to string the level if it just have one value without an array, but when event['level'] is an array, in some rare case, it may crash like that (if integer value is present in the array)
It crashs with the following stack in debug:

```
NoMethodError: undefined method `downcase' for 6:Fixnum
        receive at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-gelf-1.0.0/lib/logstash/outputs/gelf.rb:210
         handle at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.2.2-java/lib/logstash/outputs/base.rb:88
    output_func at (eval):77
   outputworker at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.2.2-java/lib/logstash/pipeline.rb:243
  start_outputs at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.2.2-java/lib/logstash/pipeline.rb:165
syslog listener died {:protocol=>:udp, :address=>"0.0.0.0:1513", :exception=>#<SocketError: recvfrom: name or service not known>, :backtrace=>["/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-syslog-1.0.0/lib/logstash/inputs/syslog.rb:138:in `udp_listener'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-syslog-1.0.0/lib/logstash/inputs/syslog.rb:117:in `server'", "/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-syslog-1.0.0/lib/logstash/inputs/syslog.rb:97:in `run'"], :level=>:warn, :file=>"logstash/inputs/syslog.rb", :line=>"120", :method=>"server"}
```

2/event ['tags'] can just be a value not always an array
If you setup Logstash into Logstash. A first logstash server with output-gelf, setup grok filter which failed, so it generated tags => ["_grokparsefailure"]. The second logstash server with gelf-input and gelf-output. The event['tags'] has in this case an array of one value on the first logstash server and just a value without an array on the second server.
It crashs with the following stack in debug:

```
NoMethodError: undefined method `join' for "_grokparsefailure":String
        receive at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-gelf-0.1.4/lib/logstash/outputs/gelf.rb:178
         handle at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/outputs/base.rb:88
    output_func at (eval):180
   outputworker at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/pipeline.rb:243
  start_outputs at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.1-java/lib/logstash/pipeline.rb:165
```
