### PR TITLE
Handle for cases when level is already numeric

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -207,7 +207,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     else
       level = event.sprintf(@level.to_s)
     end
-    m["level"] = (@level_map[level.downcase] || level).to_i
+    m["level"] = (level.respond_to?(:downcase) && @level_map[level.downcase] || level).to_i
 
     @logger.debug(["Sending GELF event", m])
     begin


### PR DESCRIPTION
I believe this is related to https://github.com/elastic/logstash/issues/3888, but that issue hasn't been relocated to the correct project yet. My issue was discovered against 1.5.4-1, as provided by the packages.elasticsearch.org repo.

If Logstash is receiving messages where the "level" field is already numeric (from TCP/JSON in my case, from UDP/CollectD in the original issue's case), GELF output fails with the following error:

```
NoMethodError: undefined method `downcase' for 4:Fixnum
        receive at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-gelf-1.0.0/lib/logstash/outputs/gelf.rb:200
         handle at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/outputs/base.rb:88
    output_func at (eval):300
   outputworker at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/pipeline.rb:244
  start_outputs at /opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.4-java/lib/logstash/pipeline.rb:166
```

The line in question:

```
m["level"] = (@level_map[level.downcase] || level).to_i
```

Fix is to simply check if level.respond_to?(:downcase) before attempting it.
