### PR TITLE
Gelf crashes with numeric "level" fields

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -207,7 +207,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     else
       level = event.sprintf(@level.to_s)
     end
-    m["level"] = (@level_map[level.downcase] || level).to_i
+    m["level"] = (@level_map[level.to_s.downcase] || level).to_i
 
     @logger.debug(["Sending GELF event", m])
     begin

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -134,7 +134,6 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
 
     # We have to make our own hash here because GELF expects a hash
     # with a specific format.

--- a/logstash-output-gelf.gemspec
+++ b/logstash-output-gelf.gemspec
@@ -27,4 +27,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/outputs/gelf_spec.rb
+++ b/spec/outputs/gelf_spec.rb
@@ -16,7 +16,10 @@ describe LogStash::Outputs::Gelf do
 
     subject { LogStash::Outputs::Gelf.new("host" => host, "port" => port ) }
 
-    let(:properties) { { "message" => "This is a message!"} }
+    let(:properties) { {
+      "message" => "This is a message!",
+      "severity" => 7,
+    } }
     let(:event)      { LogStash::Event.new(properties) }
     let(:gelf)       { GELF::Notifier.new(host, port, subject.chunksize) }
 
@@ -28,6 +31,12 @@ describe LogStash::Outputs::Gelf do
     it "sends the generated event to gelf" do
       expect(subject.gelf).to receive(:notify!).with(hash_including("short_message"=>"This is a message!",
                                                                     "full_message"=>"This is a message!"),
+                                                     hash_including(:timestamp))
+      subject.receive(event)
+    end
+
+    it "accepts a Fixnum in the severity field" do
+      expect(subject.gelf).to receive(:notify!).with(hash_including("level"=>7),
                                                      hash_including(:timestamp))
       subject.receive(event)
     end


### PR DESCRIPTION
`LogStash::Outputs::Gelf` tries to convert word-based syslog levels to numbers. If the level being parsed is already a number, the class crashes with a `NoMethodError` because `Fixnum` doesn't have a `.downcase` method.
