### PR TITLE
Add TCP support

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -19,6 +19,9 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
   # The GELF chunksize. You usually don't need to change this.
   config :chunksize, :validate => :number, :default => 1420
 
+  # The transport protocol, either TCP or UDP.
+  config :protocol, :validate => ["TCP", "UDP"], :default => "UDP"
+
   # Allow overriding of the GELF `sender` field. This is useful if you
   # want to use something other than the event's source host as the
   # "sender" of an event. A common case for this is using the application name
@@ -80,7 +83,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     option_hash = Hash.new
 
     #@gelf = GELF::Notifier.new(@host, @port, @chunksize, option_hash)
-    @gelf ||= GELF::Notifier.new(@host, @port, @chunksize)
+    @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, { :protocol => GELF::Protocol.const_get(@protocol) })
 
     # This sets the 'log level' of gelf; since we're forwarding messages, we'll
     # want to forward *all* messages, so set level to 0 so all messages get

--- a/logstash-output-gelf.gemspec
+++ b/logstash-output-gelf.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'gelf', ['1.3.2']
+  s.add_runtime_dependency 'gelf', ['3.0.0']
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
No tests yet, but I wanted to get this out there for those that are seeking it.

A caveat: this opens a single, long-running TCP connection to Graylog, preventing a standard TCP load balancer from balancing the load. For our environment, we added an option to open multiple parallel connections which can then be distributed among our Graylog servers via HAProxy: 4e4a4a0a7944f6a3d32cf11c63c78966a579b42d (some variation of which might be considered for logstash-output-gelf).

This is a solution for logstash-plugins/logstash-output-gelf#1
