### PR TITLE
TCP TLS support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -188,6 +188,7 @@ be used
 | no_verify |<<boolean,boolean>>|`false`| Disables validation of Root CA
 | all_ciphers |<<boolean,boolean>>|`false`| Allows TLS to use any system available cipher. !Insecure!
 | rescue_ssl_errors |<<boolean,boolean>> | `false` | SSL Errors will not be handled and will bubble up into the logstash logs. Setting `true` will eat the errors and continue execution.
+| version |<<string,string>>|`"TLSv1_2"`| TLS version, other options are `"TLSv1_1"` and `"TLSv1"`
 | cert |<<string,string>>|None|The client certificate file
 | key |<<string,string>>|None|The key for the client certificate
 |=======================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,10 +40,12 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ignore_metadata>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-level>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-protocol>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sender>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ship_metadata>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ship_tags>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-short_message>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-tls>> |<<hash,hash>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -52,7 +54,7 @@ output plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-chunksize"]
-===== `chunksize` 
+===== `chunksize`
 
   * Value type is <<number,number>>
   * Default value is `1420`
@@ -60,7 +62,7 @@ output plugins.
 The GELF chunksize. You usually don't need to change this.
 
 [id="plugins-{type}s-{plugin}-custom_fields"]
-===== `custom_fields` 
+===== `custom_fields`
 
   * Value type is <<hash,hash>>
   * Default value is `{}`
@@ -71,7 +73,7 @@ e.g. `custom_fields => ['foo_field', 'some_value']`
 sets `_foo_field` = `some_value`.
 
 [id="plugins-{type}s-{plugin}-full_message"]
-===== `full_message` 
+===== `full_message`
 
   * Value type is <<string,string>>
   * Default value is `"%{message}"`
@@ -79,7 +81,7 @@ sets `_foo_field` = `some_value`.
 The GELF full message. Dynamic values like `%{foo}` are permitted here.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -88,7 +90,7 @@ The GELF full message. Dynamic values like `%{foo}` are permitted here.
 Graylog2 server IP address or hostname.
 
 [id="plugins-{type}s-{plugin}-ignore_metadata"]
-===== `ignore_metadata` 
+===== `ignore_metadata`
 
   * Value type is <<array,array>>
   * Default value is `["@timestamp", "@version", "severity", "host", "source_host", "source_path", "short_message"]`
@@ -97,7 +99,7 @@ Ignore these fields when `ship_metadata` is set. Typically this lists the
 fields used in dynamic values for GELF fields.
 
 [id="plugins-{type}s-{plugin}-level"]
-===== `level` 
+===== `level`
 
   * Value type is <<array,array>>
   * Default value is `["%{severity}", "INFO"]`
@@ -115,12 +117,21 @@ are accepted: "emergency", "alert", "critical",  "warning", "notice", and
 "informational".
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * Value type is <<number,number>>
   * Default value is `12201`
 
 Graylog2 server port number.
+
+[id="plugins-{type}s-{plugin}-protocol"]
+===== `protocol`
+
+  * Value type is <<string,string>>
+  * Default value is `"UDP"`
+
+GELF message network Protocol. +
+Set to `"TCP"` for TCP and TCPTLS
 
 [id="plugins-{type}s-{plugin}-sender"]
 ===== `sender` 
@@ -161,7 +172,40 @@ event as the field `\_tags`.
 The GELF short message field name. If the field does not exist or is empty,
 the event message is taken instead.
 
+[id="plugins-{type}s-{plugin}-tls"]
+===== `tls`
 
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+TLS configuration Hash. +
+If protocol is set to `"TCP"` and this hash contains at least one value, then TLS over TCP will
+be used
+
+[cols="<,<,<,<",options="header",]
+|=======================================================================
+|Name |Input type|Default|Detail
+| no_verify |<<boolean,boolean>>|`false`| Disables validation of Root CA
+| all_ciphers |<<boolean,boolean>>|`false`| Allows TLS to use any system available cipher. !Insecure!
+| rescue_ssl_errors |<<boolean,boolean>> | `false` | SSL Errors will not be handled and will bubble up into the logstash logs. Setting `true` will eat the errors and continue execution.
+| cert |<<string,string>>|None|The client certificate file
+| key |<<string,string>>|None|The key for the client certificate
+|=======================================================================
+
+A sample TLS configuration to get things started is below.
+----
+output {
+    gelf {
+        protocol => "TCP"
+        host => "localhost"
+        port=> xxxxxx
+        tls => {
+            all_ciphers => true
+            no_verify => true
+        }
+    }
+ }
+----
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -89,6 +89,8 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     if !@tls.empty?
       option_hash['tls'] = @tls
       option_hash['tls']['version'] = tls_version
+      # Makes SSL Errors float up and be logged
+      option_hash['tls']['rescue_ssl_errors'] = false
     end 
 
     @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, option_hash)

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -67,6 +67,10 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
   # the event message is taken instead.
   config :short_message, :validate => :string, :default => "short_message"
 
+  # The GELF tls field mappings. 
+  # See https://github.com/graylog-labs/gelf-rb/blob/master/lib/gelf/transport/tcp_tls.rb
+  config :tls, :validate => :hash, :default => {}
+
   public
 
   def inject_client(gelf)
@@ -81,9 +85,14 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
   def register
     require "gelf" # rubygem 'gelf'
     option_hash = Hash.new
+    option_hash['protocol'] = GELF::Protocol.const_get(@protocol)
+    if !@tls.empty?
+      option_hash['tls'] = @tls
+      option_hash['tls']['version'] = tls_version
+    end 
 
-    #@gelf = GELF::Notifier.new(@host, @port, @chunksize, option_hash)
-    @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, { :protocol => GELF::Protocol.const_get(@protocol) })
+    @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, option_hash)
+    #@gelf ||= GELF::Notifier.new(@host, @port, @chunksize, { :protocol => GELF::Protocol.const_get(@protocol) })
 
     # This sets the 'log level' of gelf; since we're forwarding messages, we'll
     # want to forward *all* messages, so set level to 0 so all messages get
@@ -119,10 +128,23 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
      }
   end # def register
 
+  def tls_version
+    if @tls.key?('version')
+      METHODS_MAP[@tls['version']] or :TLSv1_2
+    else
+      :TLSv1_2
+    end
+  end
+  METHODS_MAP = {
+    "TLSv1" => :TLSv1,
+    "TLSv1_1" => :TLSv1_1,
+    "TLSv1_2" => :TLSv1_2,
+  }.freeze
+  private_constant :METHODS_MAP
+
   public
   def receive(event)
     
-
     # We have to make our own hash here because GELF expects a hash
     # with a specific format.
     m = Hash.new
@@ -189,7 +211,6 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
       level = event.sprintf(@level.to_s)
     end
     m["level"] = (level.respond_to?(:downcase) && @level_map[level.downcase] || level).to_i
-
     @logger.debug("Sending GELF event", :event => m)
     begin
       @gelf.notify!(m, :timestamp => event.timestamp.to_f)


### PR DESCRIPTION
Adds TCP TLS Support via [tcp_tls.rb
](https://github.com/graylog-labs/gelf-rb/blob/master/lib/gelf/transport/tcp_tls.rb)
With the current implementation of gelf-rb, there are 2 issues

1. All SSL Errors are eaten, so a user cannot see any problems in the logs.
2. The Default Ciphers are incorrect, so a default TLS config always fail (invisibly due to problem 1)

With the current implementation of gelf-rb and this PR, a working test can be achieved with 
`bin/logstash -e 'input { stdin { } } output {gelf {tls => {**all_ciphers => true** no_verify => true} protocol => "TCP" host => "localhost" port=> xxxxxx}}'`
**This allows all ciphers, including some insecure ones**

I have submitted a pull request to gelf-rb https://github.com/graylog-labs/gelf-rb/pull/68
That fixes both of the above problems and limits the usable Ciphers to ones not cryptographically broken yet trying to keep broad compatibility.

Once that PR has been accepted and that implementation is in use, the following cmd can be used
`bin/logstash -e 'input { stdin { } } output {gelf {tls => {no_verify => true} protocol => "TCP" host => "localhost" port=> xxxxx}}'`
and SSL Errors will also now bubble up into the logstash logs.

This will also fix https://github.com/logstash-plugins/logstash-output-gelf/issues/26