### PR TITLE
Use .nil? for nil check

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -143,7 +143,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
 
     if @ship_metadata
       event.to_hash.each do |name, value|
-        next if value == nil
+        next if value.nil?
         next if name == "message"
 
         # Trim leading '_' in the event


### PR DESCRIPTION
Currently the metadata nil check uses `value == nil`, unfortunately this causes issues with time fields and the time comparator with an exception:

```
[2017-11-15T23:01:51,491][FATAL][logstash.runner          ] An unexpected error occurred! {:error=>#<NoMethodError: undefined method `time' for nil:NilClass>, :backtrace=>["/usr/share/logstash/logstash-core/lib/logstash/timestamp.rb:13:in `<=>'", "org/jruby/RubyComparable.java:150:in `=='", "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-output-gelf-3.1.4/lib/logstash/outputs/gelf.rb:146:in `block in receive'", "org/jruby/RubyHash.java:1343:in `each'", "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-output-gelf-3.1.4/lib/logstash/outputs/gelf.rb:145:in `receive'", "/usr/share/logstash/logstash-core/lib/logstash/outputs/base.rb:92:in `block in multi_receive'", "org/jruby/RubyArray.java:1734:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/outputs/base.rb:92:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/output_delegator_strategies/legacy.rb:22:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/output_delegator.rb:49:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:538:in `block in output_batch'", "org/jruby/RubyHash.java:1343:in `each'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:536:in `output_batch'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:481:in `worker_loop'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:439:in `block in start_workers'"]}
```

This modifies the code so the nil check is not an equality check but rather a Ruby `nil?` check