### PR TITLE
doc: document the protocol option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 3.1.6
+  - Add docs for TCP protocol option, which has existed since 3.1.3
+
 ## 3.1.5
   - Update gemspec summary
 
 ## 3.1.4
   - Fix some documentation issues
+
+## 3.1.3
+  - Add support for output via TCP protocol
 
 ## 3.1.2
   - Remove call of logger with an array object which caused logstash to terminate

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,6 +40,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ignore_metadata>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-level>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-protocol>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sender>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ship_metadata>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ship_tags>> |<<boolean,boolean>>|No
@@ -121,6 +122,17 @@ are accepted: "emergency", "alert", "critical",  "warning", "notice", and
   * Default value is `12201`
 
 Graylog2 server port number.
+
+[id="plugins-{type}s-{plugin}-protocol"]
+===== `protocol`
+
+By default, this plugin outputs via the UDP transfer protocol, but can be
+configured to use TCP instead.
+
+  * Value type is <<string,string>>
+  * Default value is `"UDP"`
+
+Values here can be either "TCP" or "UDP".
 
 [id="plugins-{type}s-{plugin}-sender"]
 ===== `sender` 

--- a/logstash-output-gelf.gemspec
+++ b/logstash-output-gelf.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-gelf'
-  s.version         = '3.1.5'
+  s.version         = '3.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Generates GELF formatted output for Graylog2"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds documentation for the `protocol` option, which allows a user to configure
this plugin to output via the TCP transport protocol instead of the default
UDP, which was added in 3.1.3 via logstash-plugins/logstash-output-gelf#19

Resolves: logstash-plugins/logstash-output-gelf#1
