### PR TITLE
changed GELF Link to stable

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,7 @@ include::{include_path}/plugin_header.asciidoc[]
 This output generates messages in GELF format. This is most useful if you
 want to use Logstash to output events to Graylog2.
 
-More information at http://docs.graylog.org/en/2.3/pages/gelf.html#gelf-payload-specification[The Graylog2 GELF specs page]
+More information at http://docs.graylog.org/en/stable/pages/gelf.html#gelf-payload-specification[The Graylog2 GELF specs page]
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Gelf Output Configuration Options


### PR DESCRIPTION
After notice that the GELF spec link is into the documentation of a specific version of Graylog this change switched this to the stable link.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
