### PR TITLE
Add support for TLS settings

### DIFF
--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -72,7 +72,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
   config :ssl_certificate_authorities, :validate => :string, :default => ""
   config :ssl_certificate, :validate => :string, :default => ""
   config :ssl_key, :validate => :string, :default => ""
-  config :ssl_verify_mode, validate => :string, :default => "force_peer"
+  config :ssl_verify_mode, :validate => :string, :default => "force_peer"
 
   public
 

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -93,7 +93,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
 
     if @ssl
       option_hash['tls'] = Hash.new
-      option_hash['tls']['ca'] = @ssl_certificate_authorities != ""
+      option_hash['tls']['ca'] = @ssl_certificate_authorities if @ssl_certificate_authorities != ""
       option_hash['tls']['no_default_ca'] = true if @ssl_certificate_authorities != ""
       option_hash['tls']['cert'] = @ssl_certificate if @ssl_certificate != ""
       option_hash['tls']['key'] = @ssl_key if @ssl_key != ""

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -93,12 +93,11 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
 
     if @ssl
       option_hash['tls'] = true
+      option_hash['ca'] = @ssl_certificate_authorities != ""
+      option_hash['cert'] = @ssl_certificate if @ssl_certificate != ""
+      option_hash['key'] = @ssl_key if @ssl_key != ""
+      option_hash['no_verify'] = false if @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"
     end
-
-    option_hash['ssl_certificate_authorities'] = @ssl_certificate_authorities != ""
-    option_hash['ssl_certificate'] = @ssl_certificate if @ssl_certificate != ""
-    option_hash['ssl_key'] = @ssl_key if @ssl_key != ""
-    option_hash['ssl_verify_mode'] = @ssl_verify_mode if @ssl_verify_mode != ""
 
     @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, option_hash)
 

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -94,6 +94,7 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     if @ssl
       option_hash['tls'] = Hash.new
       option_hash['tls']['ca'] = @ssl_certificate_authorities != ""
+      option_hash['tls']['no_default_ca'] = true if @ssl_certificate_authorities != ""
       option_hash['tls']['cert'] = @ssl_certificate if @ssl_certificate != ""
       option_hash['tls']['key'] = @ssl_key if @ssl_key != ""
       option_hash['tls']['no_verify'] = false if @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"

--- a/lib/logstash/outputs/gelf.rb
+++ b/lib/logstash/outputs/gelf.rb
@@ -92,11 +92,13 @@ class LogStash::Outputs::Gelf < LogStash::Outputs::Base
     option_hash['protocol'] = GELF::Protocol.const_get(@protocol)
 
     if @ssl
-      option_hash['tls'] = true
-      option_hash['ca'] = @ssl_certificate_authorities != ""
-      option_hash['cert'] = @ssl_certificate if @ssl_certificate != ""
-      option_hash['key'] = @ssl_key if @ssl_key != ""
-      option_hash['no_verify'] = false if @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"
+      option_hash['tls'] = Hash.new
+      option_hash['tls']['ca'] = @ssl_certificate_authorities != ""
+      option_hash['tls']['cert'] = @ssl_certificate if @ssl_certificate != ""
+      option_hash['tls']['key'] = @ssl_key if @ssl_key != ""
+      option_hash['tls']['no_verify'] = false if @ssl_verify_mode == "force_peer" || @ssl_verify_mode == "peer"
+      # Makes SSL Errors float up and be logged
+      option_hash['tls']['rescue_ssl_errors'] = false
     end
 
     @gelf ||= GELF::Notifier.new(@host, @port, @chunksize, option_hash)


### PR DESCRIPTION
The rubygem gelf library supports ssl since it's version 3.0.0. This PR adds new SSL options to logstash-output-gelf. This is pretty much a reimplementation of #28. 

**Parameters**
- ssl (boolean)
- ssl_certificate_authorities (string)
- ssl_certificate (string)
- ssl_key (string)
- ssl_verify_mode ([none, peer, force_peer])

Currently there is no option for ssl_ciphers as the gelf library dosen't have any kind of cipherlist option. 

Please review and let me know if any changes are necessary.
